### PR TITLE
Clarify the distinction between variables, references, and values.

### DIFF
--- a/exercises/move_semantics/move_semantics1.rs
+++ b/exercises/move_semantics/move_semantics1.rs
@@ -4,21 +4,21 @@
 // I AM NOT DONE
 
 fn main() {
-    // Here vec0 is an immutable reference to the heap-allocated vector
-    // (basically a dynamic array). From here on out, vec0 cannot be used to
-    // modify the underlying memory in the vector (even though the memory is
-    // heap-allocated and totally supports growing and shrinking based on
-    // runtime usage). Anyway, making vec0 immutable here is OK because we don't
-    // use vec0 from within this scope to modify it. So, someone else is free to
-    // grow the vector, just not us.
+    // Here vec0 is an immutable variable containing a vector (basically a
+    // dynamic array). From here on out, vec0 cannot be used to modify the
+    // underlying memory in the vector (even though the memory is heap-allocated
+    // and totally supports growing and shrinking based on runtime usage).
+    // Anyway, making vec0 immutable here is OK because we don't use vec0 to
+    // modify the vector. So, someone else is free to grow the vector, just not
+    // us.
     let vec0 = Vec::new();
 
-    // Indeed, we just pass along this immutable reference to fill_vec(), which
-    // can grow it. Even though fill_vec() will grow the vector, it's OK because
-    // fill_vec() is the one doing the growing, NOT main().
+    // Indeed, we just pass along the value to fill_vec(), which can grow it.
+    // Even though fill_vec() will grow the vector, it's OK because fill_vec()
+    // is the one doing the growing, NOT main().
     //
-    // When fill_vec() is done it returns the same memory location back to us
-    // (the same region of memory pointed-to by vec0).
+    // When fill_vec() is done it returns the modified vector back to us
+    // (pointing to the same region of heap memory pointed-to by vec0).
     //
     // When we create vec1, we're saying that we still want to make it
     // immutable. There's nothing wrong with this per-se, it's just that we

--- a/exercises/move_semantics/move_semantics2.rs
+++ b/exercises/move_semantics/move_semantics2.rs
@@ -6,7 +6,7 @@
 
 fn main() {
     // Approach 3 (from "rustlings hint move_semantics2"): Just create a single
-    // mutable reference, and make fill_vec() grow it directly. So now
+    // mutable variable, and make fill_vec() grow it directly. So now
     // fill_vec() expects a mutable reference to borrow (no new vectors are
     // being created in this program). In other words, the other 2 approaches
     // involve a deep copy, but this one does not. It doesn't even involve
@@ -25,7 +25,7 @@ fn main() {
     // into fill_vec().
     //
     // The thing to remember is that whenever a move occurs, essentially the
-    // original pointer is dropped (destroyed). This is explained in
+    // original variable is destroyed (becomes invalid). This is explained in
     // https://doc.rust-lang.org/book/ch04-01-what-is-ownership.html#ways-variables-and-data-interact-move
     // (please read this subsection in its entirety as it has pictures and
     // everything to make it easy!). So here, vec0 is the original pointer to

--- a/exercises/move_semantics/move_semantics3.rs
+++ b/exercises/move_semantics/move_semantics3.rs
@@ -22,10 +22,10 @@ fn main() {
 
 // Here we are quite simply modifying the underlying memory pointed by vec,
 // by calling push(). As it stands though, the declaration in the parameter
-// list "vec: Vec<i32>" states that "vec" is an immutable reference. And so
+// list "vec: Vec<i32>" states that "vec" is an immutable variable. And so
 // either we have to perform only non-mutating (read-only) operations on it,
 // or, if we want to keep the push() calls to modify it, declare that we
-// expect to take a mutable reference to it instead.
+// expect it to be mutable instead.
 //
 // Q: How do we make "vec" mutable?
 // A: Just add the "mut" keyword to make the argument "mut vec: Vec<i32>". Note

--- a/exercises/move_semantics/move_semantics4.rs
+++ b/exercises/move_semantics/move_semantics4.rs
@@ -20,7 +20,7 @@ fn main() {
 //
 // Q: How can we make fill_vec() create a new vector from scratch?
 //
-// A: We just move the heap allocation call (Vec::new()) from main() to be
+// A: We just move the vector creation (Vec::new()) from main() to be
 // within fill_vec()'s definition.
 //
 // This is exactly like Vec::new() itself, but with a twist that it just comes


### PR DESCRIPTION
Variables can be either uninitialized (generally invalid) or contain a value. That value can be a reference or another type (such as a vector). Furthermore, those values can own memory, as `Vec` does. I tried to make this more clear.

I also tweaked a few mentions of dynamic memory allocation. E.g. `Vec::new()` doesn't perform heap allocation, it only returns a new `Vec` value.